### PR TITLE
Fixes audio controller

### DIFF
--- a/Game/Assets/Scenes/02-menu.unity
+++ b/Game/Assets/Scenes/02-menu.unity
@@ -630,49 +630,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 97274686}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &101973014
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 101973015}
-  - component: {fileID: 101973016}
-  m_Layer: 0
-  m_Name: AudioManager
-  m_TagString: AudioManager
-  m_Icon: {fileID: 4422084297763085224, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &101973015
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 101973014}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 74.74443, y: 152.87057, z: -381.75}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &101973016
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 101973014}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8da060fc82d5ad64ebd66c3122626c59, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &113065824
 GameObject:
   m_ObjectHideFlags: 0
@@ -10129,3 +10086,72 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 74acd0d6735bf724398b2ccf22cf94b4, type: 3}
+--- !u!1001 &4754754890215024112
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4754754890314717670, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_Name
+      value: AudioManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 74.74443
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 152.87057
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -381.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9cfd5a608c002746bfc1e690f6e0ab5, type: 3}

--- a/Game/Assets/Scenes/03-game.unity
+++ b/Game/Assets/Scenes/03-game.unity
@@ -852,7 +852,6 @@ GameObject:
   - component: {fileID: 78200799}
   - component: {fileID: 78200798}
   - component: {fileID: 78200796}
-  - component: {fileID: 78200795}
   - component: {fileID: 78200794}
   - component: {fileID: 78200793}
   - component: {fileID: 78200792}
@@ -1109,14 +1108,6 @@ MonoBehaviour:
   pinchModeDetectionMoveTreshold: 0.025
   pinchTiltModeThreshold: 0.0075
   pinchTiltSpeed: 180
---- !u!81 &78200795
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 78200791}
-  m_Enabled: 1
 --- !u!124 &78200796
 Behaviour:
   m_ObjectHideFlags: 0
@@ -1926,6 +1917,75 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 173900309}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &181104984
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4754754890314717670, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_Name
+      value: AudioManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 74.74443
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 152.87057
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -381.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4754754890314717671, guid: d9cfd5a608c002746bfc1e690f6e0ab5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9cfd5a608c002746bfc1e690f6e0ab5, type: 3}
 --- !u!1001 &185632274
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14030,6 +14090,7 @@ GameObject:
   - component: {fileID: 1667236021}
   - component: {fileID: 1667236020}
   - component: {fileID: 1667236022}
+  - component: {fileID: 1667236023}
   m_Layer: 0
   m_Name: GameController
   m_TagString: Untagged
@@ -14182,6 +14243,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9bf713b3244cce140a787e11d3f3a77b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1667236023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1667236016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b393cc09b7d785546948ec01af7bc209, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playWhen: 0
+  volume: 1
+  audioClip: {fileID: 8300000, guid: 43878d018f4b1994d8d5c174587ae949, type: 3}
+  repeat: 1
 --- !u!1001 &1670860035
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Game/Assets/UI/AudioManager.prefab
+++ b/Game/Assets/UI/AudioManager.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4754754890314717670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4754754890314717671}
+  - component: {fileID: 4754754890314717672}
+  m_Layer: 0
+  m_Name: AudioManager
+  m_TagString: AudioManager
+  m_Icon: {fileID: 4422084297763085224, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4754754890314717671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754754890314717670}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 74.74443, y: 152.87057, z: -381.75}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4754754890314717672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4754754890314717670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8da060fc82d5ad64ebd66c3122626c59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Game/Assets/UI/AudioManager.prefab.meta
+++ b/Game/Assets/UI/AudioManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d9cfd5a608c002746bfc1e690f6e0ab5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Game/Assets/UI/Scripts/AudioManagerController.cs
+++ b/Game/Assets/UI/Scripts/AudioManagerController.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class AudioManagerController : MonoBehaviour {
     public enum EventType {
@@ -12,10 +13,25 @@ public class AudioManagerController : MonoBehaviour {
     private AudioSource effectSource;
     private AudioSource musicSource;
     private float savedVolume = 0f;
+    private AudioListener audioListener;
 
     public static AudioManagerController Instance => instance;
 
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode) {
+        if (audioListener == null) {
+            AudioListener existingAudioListener = FindObjectOfType<AudioListener>();
+
+            if (existingAudioListener == null) {
+                audioListener = gameObject.AddComponent<AudioListener>();
+            } else {
+                audioListener = existingAudioListener;
+            }
+        }
+    }
+
     private void Awake() {
+        Debug.Log("on awake");
+
         if (Instance == null) {
             instance = this;
         } else if (Instance != this) {
@@ -23,6 +39,8 @@ public class AudioManagerController : MonoBehaviour {
         }
 
         DontDestroyOnLoad(gameObject);
+
+        SceneManager.sceneLoaded += OnSceneLoaded;
 
         if (musicSource == null || effectSource == null) {
             effectSource = gameObject.AddComponent<AudioSource>();

--- a/Game/Assets/UI/Scripts/AudioManagerController.cs.meta
+++ b/Game/Assets/UI/Scripts/AudioManagerController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 100
   icon: {fileID: 4422084297763085224, guid: 0000000000000000d000000000000000, type: 0}
   userData: 
   assetBundleName: 

--- a/Game/Assets/UI/Scripts/PlayMusic.cs
+++ b/Game/Assets/UI/Scripts/PlayMusic.cs
@@ -4,7 +4,7 @@ public class PlayMusic : PlaySfx {
     [SerializeField] private bool repeat;
 
     public override void Play() {
-        audioManagerController.PlaySfx(audioClip, volume);
+        audioManagerController.PlayMusic(audioClip, volume);
     }
 
     void OnDestroy() {

--- a/Game/Assets/UI/Scripts/PlaySfx.cs
+++ b/Game/Assets/UI/Scripts/PlaySfx.cs
@@ -37,6 +37,6 @@ public class PlaySfx : MonoBehaviour {
     }
 
     public virtual void Play() {
-        audioManagerController.PlayMusic(audioClip, volume);
+        audioManagerController.PlaySfx(audioClip, volume);
     }
 }


### PR DESCRIPTION
**Features:**
✔️ Adds `audioListener` to `AudioController` when it does not exist and check again on every scene load.

**Bugs:**
🐛 Fixes `AudioController`

**Root cause:** `PlaySfx` was invoking method for music and the other way around, `PlayMusic` calling the one for sfx.