### PR TITLE
Implementing loop-a-doop

### DIFF
--- a/Game/Assets/UI/Scripts/AudioManagerController.cs
+++ b/Game/Assets/UI/Scripts/AudioManagerController.cs
@@ -54,10 +54,11 @@ public class AudioManagerController : MonoBehaviour {
         effectSource.PlayOneShot(clip, volume);
     }
 
-    public void PlayMusic(AudioClip clip, float volume) {
+    public void PlayMusic(AudioClip clip, float volume, bool repeat) {
         // TODO multiply by global volume
         musicSource.clip = clip;
         musicSource.volume = volume;
+        musicSource.loop = repeat;
         musicSource.Play();
     }
 

--- a/Game/Assets/UI/Scripts/PlayMusic.cs
+++ b/Game/Assets/UI/Scripts/PlayMusic.cs
@@ -4,7 +4,7 @@ public class PlayMusic : PlaySfx {
     [SerializeField] private bool repeat;
 
     public override void Play() {
-        audioManagerController.PlayMusic(audioClip, volume);
+        audioManagerController.PlayMusic(audioClip, volume, repeat);
     }
 
     void OnDestroy() {


### PR DESCRIPTION
Adds:
✔️ Implements loop for music 🎵. The file already had the flag for the editor, but it wasn't yet implemented. This is expecting to not break any serialized scene since serializable fields remain unchanged.
